### PR TITLE
removing outdated error check

### DIFF
--- a/src/psy_tools.py
+++ b/src/psy_tools.py
@@ -90,10 +90,7 @@ def process_session(bsid,complete=True,version=None,format_options={},refit=Fals
         models = dropout_analysis(psydata, strategies, format_options)
 
     print('Packing up and saving')
-    try:
-        metadata = session.metadata
-    except:
-        metadata = []
+    metadata = session.metadata
     output = [ hyp,   evd,   wMode,   hess,   credibleInt,   weights,   ypred,  psydata,  cross_results,  cv_pred,  metadata]
     labels = ['hyp', 'evd', 'wMode', 'hess', 'credibleInt', 'weights', 'ypred','psydata','cross_results','cv_pred','metadata']       
     fit = dict((x,y) for x,y in zip(labels, output))
@@ -472,11 +469,8 @@ def format_session(session,format_options):
                 'image_ids': df.index.values,
                 'df':df,
                 'full_df':full_df }
-    # TODO, this is probably outdated, right? Issue #138
-    try: 
-        psydata['session_label'] = [session.metadata['stage']]
-    except:
-        psydata['session_label'] = ['Unknown Label']  
+
+    psydata['session_label'] = [session.metadata['stage']]
     return psydata
 
 


### PR DESCRIPTION
- resolves #138 
- [x] lots of things where I check data issues should be resolved by the SDK updates.
   - [x] try/except around session.metadata 
   - [x] poked around and couldn't find any others. They may have been resolved with all the recent updates
- Are there other places where I should be defensive about abnormal data?
   - I think recent QC in bouts/licks annotations resolves this issue. With the exception of the session with abnormal stimulus variability #152 
- [x] Data selection
   - The model does not fit to sessions with less than 10 licks. `ps.format_session` 
   - In some places I filter out sessions with less than 5 hits (PCA functions have `hit_threshold=0`)
   - This might be related to #253. If I increase the restriction on number of licks or number of hits I will probably greatly reduce the occurrence of the singular factor issue. I should manually check what reasonable thresholds should be. 
   - I'm moving this issue to #253