### PR TITLE
adding engagement_v1 and _v2 for neural analysis

### DIFF
--- a/src/psy_general_tools.py
+++ b/src/psy_general_tools.py
@@ -372,12 +372,13 @@ def get_strategy_list(version):
         raise Exception('Unknown model version')
     return strategies
 
+
 def get_engagement_threshold():
     '''
         Definition for engagement in units of rewards/sec
-        1 reward every 90 seconds
     '''
     return 1/120
+
     
 def get_bout_threshold():
     '''

--- a/src/psy_output_tools.py
+++ b/src/psy_output_tools.py
@@ -164,12 +164,25 @@ def build_summary_table(version):
 
     print('Adding engagement information') 
     summary_df = add_engagement_metrics(summary_df) 
+    summary_df = temporary_engagement_updates(summary_df)
+
 
     print('Saving')
     model_dir = pgt.get_directory(version,subdirectory='summary') 
     summary_df.to_pickle(model_dir+'_summary_table.pkl')
 
     return summary_df 
+
+def temporary_engagement_updates(summary_df):
+    summary_df['engagement_v1'] = [[]]*len(summary_df)      
+    summary_df['engagement_v2'] = [[]]*len(summary_df)      
+    summary_df['engagement_v1'] = summary_df['engaged']
+    v2 = []
+    for index, row in tqdm(summary_df.iterrows(), total=summary_df.shape[0]):
+        this = np.array([x[0] and x[1] > 0.1 for x in zip(row.engagement_v1, row.lick_bout_rate)])
+        v2.append(this)
+    summary_df['engagement_v2'] = v2
+    return summary_df
 
 def build_core_table(version,include_4x2=False):
     '''

--- a/src/psy_visualization.py
+++ b/src/psy_visualization.py
@@ -1442,7 +1442,7 @@ def plot_engagement_landscape(summary_df,version, savefig=False,group=None,
         plt.savefig(filename)
 
 
-def RT_by_group(summary_df,version,bins=44,ylim=None,
+def RT_by_group(summary_df,version,bins=44,ylim=None,key='engaged',
     groups=['visual_strategy_session','not visual_strategy_session'],
     engaged='engaged',labels=['visual','timing'],change_only=False,
     density=True,savefig=False,group=None,filetype='.png',width=4.75):
@@ -1472,7 +1472,7 @@ def RT_by_group(summary_df,version,bins=44,ylim=None,
     for gindex, g in enumerate(groups):
         RT = []
         for index, row in summary_df.query(g).iterrows():
-            vec = row['engaged']
+            vec = row[key]
             if engaged=='engaged':
                 vec[np.isnan(vec)] = False
                 vec = vec.astype(bool)
@@ -1532,7 +1532,7 @@ def RT_by_group(summary_df,version,bins=44,ylim=None,
 
 
 def RT_by_engagement(summary_df,version,bins=44,change_only=False,density=False,
-    savefig=False,group=None,filetype='.svg'):
+    savefig=False,group=None,filetype='.svg',key='engaged'):
     ''' 
         Plots a distribution of response times (RT) in ms for engaged and 
         disengaged behavior 
@@ -1544,7 +1544,7 @@ def RT_by_engagement(summary_df,version,bins=44,change_only=False,density=False,
     # Aggregate data
     RT_engaged = []
     for index, row in summary_df.iterrows():
-        vec = row['engaged']
+        vec = row[key]
         vec[np.isnan(vec)] = False
         vec = vec.astype(bool)
         if change_only:
@@ -1554,7 +1554,7 @@ def RT_by_engagement(summary_df,version,bins=44,change_only=False,density=False,
         RT_engaged.append(row['RT'][vec])
     RT_disengaged = []
     for index, row in summary_df.iterrows():
-        vec = row['engaged']
+        vec = row[key]
         vec[np.isnan(vec)] = True
         vec = ~vec.astype(bool)
         if change_only:


### PR DESCRIPTION
Adding two new engagement metrics into the summary table for neural analysis
v1 is the same as "engaged" but just for parallel structure I added it as a quick fix
- [x] resolves #319 